### PR TITLE
Updates podspec, removing the XCTest framework

### DIFF
--- a/cineio-ios.podspec
+++ b/cineio-ios.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files        = [ 'cineio-ios/cineio-ios/*.h', 'cineio-ios/cineio-ios/*.m*',
                             'cineio-ios/cineio-ios/*.c*' ]
 
-  s.frameworks          = [ 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit', 'XCTest' ]
+  s.frameworks          = [ 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit' ]
 
   s.dependency          'AFNetworking', '~> 2.2.4'
   s.dependency          'VideoCore', '~> 0.1.6'


### PR DESCRIPTION
Including the XCTest framework seems to be causing a linking error in release builds. Much like this:
http://stackoverflow.com/questions/22496574/ios-application-will-not-launch-from-adhoc-distribution-because-it-cant-find-xc
