### PR TITLE
Update CineBroadcasterProtocol.h

### DIFF
--- a/cineio-ios/cineio-ios/CineBroadcasterProtocol.h
+++ b/cineio-ios/cineio-ios/CineBroadcasterProtocol.h
@@ -33,7 +33,7 @@ enum CineStreamState {
 @property (nonatomic, assign) int framesPerSecond;
 @property (nonatomic, assign) float sampleRateInHz;
 @property (nonatomic, assign) BOOL torchOn;
-@property (nonatomic, assign) CineCameraState cameraState;
-@property (nonatomic, readonly) CineStreamState streamState;
+@property (nonatomic, assign) enum CineCameraState cameraState;
+@property (nonatomic, readonly) enum CineStreamState streamState;
 
 @end


### PR DESCRIPTION
there is an error "Must use 'enum' tag to refer to type 'CineCameraState'"
