### PR TITLE
CineConstants missing Foundation import

### DIFF
--- a/cineio-broadcast-ios/cineio-broadcast-ios/CineConstants.h
+++ b/cineio-broadcast-ios/cineio-broadcast-ios/CineConstants.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+
 #define API_VERSION "1"
 #define BASE_URL "https://www.cine.io/api/"
 #define SDK_VERSION "0.6.1"

--- a/cineio-broadcast-ios/cineio-broadcast-ios/CineConstants.h
+++ b/cineio-broadcast-ios/cineio-broadcast-ios/CineConstants.h
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 #define API_VERSION "1"
 #define BASE_URL "https://www.cine.io/api/"
 #define SDK_VERSION "0.6.1"


### PR DESCRIPTION
When I try to import `CineConstants.h` I get the build error `unknown type name 'NSString'`. Adding an import of `Foundation/Foundation.h` in `CineConstants.h` solves this.